### PR TITLE
Proposal to change Nework initialization file format to TOML

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -48,31 +48,31 @@ connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
 ### Example
 ```toml
 [[drone]]  
-id = "d1"  
-connected_drone_ids = ["d3", "d4", "d5"]  
+id = 1  
+connected_drone_ids = [2, 3]  
 pdr = 0.05  
   
 [[drone]]  
-id = "d2"  
-connected_drone_ids = ["d1", "d8"]  
+id = 2 
+connected_drone_ids = [1,3,4]  
 pdr = 0.03  
   
 [[drone]]  
-id = "d3"  
-connected_drone_ids = ["d2", "d6", "d5"]  
+id = 3  
+connected_drone_ids = [2,1,4]  
 pdr = 0.14  
   
 [[client]]  
-id = "c1"  
-connected_drone_ids = ["d2", "d3"]  
+id = 4 
+connected_drone_ids = [3, 2]  
   
 [[client]]  
-id = "c2"  
-connected_drone_ids = ["d1"]  
+id = 5  
+connected_drone_ids = [1]  
   
 [[server]]  
-id = "s1"  
-connected_drone_ids = ["d5","d1"]  
+id = 6  
+connected_drone_ids = [2,3]  
 ```
 
 # Drone parameters: Packet Drop Rate

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -28,7 +28,7 @@ Any number of clients, each formatted as:
 ```TOML
 [[client]]  
 id = "client_id"  
-connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
+connected_drone_ids = ["connected_id1", "..."] # max 2 entries
 ```
 - note that `connected_drone_ids` cannot contain `client_id` nor repetitions
 - note that a client cannot connect to other clients or servers
@@ -39,7 +39,7 @@ Any number of servers, each formatted as:
 ```TOML
 [[server]]  
 id = "server_id"  
-connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
+connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."] # at least 2 entries
 ```
 - note that `connected_drone_ids` cannot contain `server_id` nor repetitions
 - note that a server cannot connect to other clients or servers

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -3,38 +3,75 @@
 This document provides the specifications of the communication protocol used by the drones, the client and the servers of the network. In the following document, drones, clients and servers are collectively referred to as **nodes**. The specifications are often broken or incomplete and you must improve over them.
 
 This document also establishes some technical requirements of the project.
-
 # Network Initializer
 
 The **Network Initializer** reads a local **Network Initialization File** that encodes the network topology and the drone parameters and, accordingly, spawns the node threads and sets up the Rust channels for communicating between nodes.
 
-The Network Initialization File has the following format:
+> Importantly, the Network Initializer should also setup the Rust channels between the nodes and the Simulation Controller (see the Simulation Controller section).
 
-- 10 drone lines: `drone_id connected_drone_count connected_drone_ids packet_drop_rate`.
+## Network Initialization File
+The **Network Initialization File** is in the `.toml` format, and structured as explained below:
 
-    Consider this example line: `d1 3 d3 d4 d5 0.05`. It means that drone `d1` is connected with 3 drones `d3`, `d4` and `d5`, and that its Packet Drop Rate is 0.05 .
+### Drones
+Any number of drones, each formatted as:
+```TOML
+[[drone]]  
+id = "drone_id"  
+connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]  
+pdr = "pdr"
+```
+- note that the `pdr` is defined between 0 and 1 (0.05 = 5%).
+- note that `connected_drone_ids` cannot contain `drone_id` nor repetitions
 
-    Note that the PDR is defined between 0 and 1 (0.05 = 5%).
+### Clients
+Any number of clients, each formatted as:
+```TOML
+[[client]]  
+id = "client_id"  
+connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
+```
+- note that `connected_drone_ids` cannot contain `client_id` nor repetitions
+- note that a client cannot connect to other clients or servers.
 
-    Note that `connected_drone_ids` cannot contain `drone_id` nor repetitions.
+### Servers
+Any number of servers, each formatted as:
+```TOML
+[[server]]  
+id = "server_id"  
+connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
+```
+- note that `connected_drone_ids` cannot contain `server_id` nor repetitions
+- note that a server cannot connect to other clients or servers.
 
-- 2 client lines: `client_id connected_drone_count connected_drone_ids`.
-
-    Consider this example line: `c1 2 d2 d3`. It means that client `c1` is connected with 2 drones `d2` and `d3`.
-
-    Note that `connected_drone_ids` cannot contain `client_id` nor repetitions.
-
-    Note that a client cannot connect to other clients or servers.
-
-- 2 server lines: `server_id connected_drone_count connected_drone_ids`.
-
-    Consider this example line: `s1 2 d4 d5`. It means that server `s1` is connected with 2 drones `d4` and `d5`.
-
-    Note that `connected_drone_ids` cannot contain `server_id` nor repetitions.
-
-    Note that a server cannot connect to other clients or servers.
-
-Importantly, the Network Initializer should also setup the Rust channels between the nodes and the Simulation Controller (see the Simulation Controller section).
+### Example
+```toml
+[[drone]]  
+id = "d1"  
+connected_drone_ids = ["d3", "d4", "d5"]  
+pdr = 0.05  
+  
+[[drone]]  
+id = "d2"  
+connected_drone_ids = ["d1", "d8"]  
+pdr = 0.03  
+  
+[[drone]]  
+id = "d3"  
+connected_drone_ids = ["d2", "d6", "d5"]  
+pdr = 0.14  
+  
+[[client]]  
+id = "c1"  
+connected_drone_ids = ["d2", "d3"]  
+  
+[[client]]  
+id = "c2"  
+connected_drone_ids = ["d1"]  
+  
+[[server]]  
+id = "s1"  
+connected_drone_ids = ["d5","d1"]  
+```
 
 # Drone parameters: Packet Drop Rate
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -31,7 +31,8 @@ id = "client_id"
 connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
 ```
 - note that `connected_drone_ids` cannot contain `client_id` nor repetitions
-- note that a client cannot connect to other clients or servers.
+- note that a client cannot connect to other clients or servers
+- note that a client can be connected to at most two drones
 
 ### Servers
 Any number of servers, each formatted as:
@@ -41,7 +42,8 @@ id = "server_id"
 connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
 ```
 - note that `connected_drone_ids` cannot contain `server_id` nor repetitions
-- note that a server cannot connect to other clients or servers.
+- note that a server cannot connect to other clients or servers
+- note that a server should be connected to at least two drones
 
 ### Example
 ```toml

--- a/examples/parser.rs
+++ b/examples/parser.rs
@@ -1,0 +1,47 @@
+/*
+
+this file showcases an example of how you can parse the config found in the Network Initialization File inside some structs, which can then be used to initialize the network
+
+remember to add the Dependencies for serde and toml to Cargo.toml:
+
+[dependencies]
+toml = "0.8.19"
+serde = { version = "1.0.214", features = ["derive"] }
+
+*/
+
+use serde::Deserialize;  
+use std::fs;  
+  
+#[derive(Debug, Deserialize)]  
+struct Drone {  
+    id: u64,  
+    connected_drone_ids: Vec<u64>,  
+    pdr: f64,  
+}  
+  
+#[derive(Debug, Deserialize)]  
+struct Client {  
+    id: u64,  
+    connected_drone_ids: Vec<u64>,  
+}  
+  
+#[derive(Debug, Deserialize)]  
+struct Server {  
+    id: u64,  
+    connected_drone_ids: Vec<u64>,  
+}  
+  
+#[derive(Debug, Deserialize)]  
+struct Config {  
+    drone: Vec<Drone>,  
+    client: Vec<Client>,  
+    server: Vec<Server>,  
+}  
+  
+fn main() {  
+    let config_data = fs::read_to_string("src/config.toml").expect("Unable to read config file");  
+    // having our structs implement the Deserialize trait allows us to use the toml::from:str function to deserialize the config file into each of them
+    let config: Config = toml::from_str(&config_data).expect("Unable to parse TOML");  
+    println!("{:#?}", config);  
+}


### PR DESCRIPTION
We propose changing the `Network Initialization File` format to a `.toml` file with the advantages of:
- having the ability to add a variable amount of nodes of each type (drone/client/server), which could help with debugging
- making it easier to add other parameters in the future if needed
- no need to spend time writing a parser, the code example below  is all that's needed to parse from the proposed config file:
```rust
use serde::Deserialize;  
use std::fs;  
  
#[derive(Debug, Deserialize)]  
struct Drone {  
    id: u64,  
    connected_drone_ids: Vec<u64>,  
    pdr: f64,  
}  
  
#[derive(Debug, Deserialize)]  
struct Client {  
    id: u64,  
    connected_drone_ids: Vec<u64>,  
}  
  
#[derive(Debug, Deserialize)]  
struct Server {  
    id: u64,  
    connected_drone_ids: Vec<u64>,  
}  
  
#[derive(Debug, Deserialize)]  
struct Config {  
    drone: Vec<Drone>,  
    client: Vec<Client>,  
    server: Vec<Server>,  
}  
  
fn main() {  
    let config_data = fs::read_to_string("src/config.toml").expect("Unable to read config file");  
    let config: Config = toml::de::from_str(&config_data).expect("Unable to parse TOML");  
    println!("{:#?}", config);  
}
```