### PR TITLE
Change chat server entry in Message Content

### DIFF
--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -35,6 +35,8 @@ pub enum MessageContent {
 
     ReqClientList,
     ReqRegisterInClientList,
+    ReqChatMsgSend { to: NodeId, chat_msg: Vec<u8> },
+    ReqNewChatMsgs,
 
     // Server -> Client
     RespServerType(ServerType),
@@ -45,8 +47,14 @@ pub enum MessageContent {
     ErrRequestedNotFound,
 
     RespClientList(Vec<NodeId>),
-    RespMessageFrom { from: NodeId, message: Vec<u8> },
+    ResqNewMsgs(Vec<ChatMsg>),
     ErrWrongClientId,
+}
+
+#[derive(Debug)]
+pub struct ChatMsg {
+    from: NodeId,
+    chat_msg: Vec<u8>,
 }
 
 impl Message {

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -34,7 +34,7 @@ pub enum MessageContent {
     ReqMedia(u64),
 
     ReqClientList,
-    ReqMessageSend { to: NodeId, message: Vec<u8> },
+    ReqRegisterInClientList,
 
     // Server -> Client
     RespServerType(ServerType),


### PR DESCRIPTION
In this PR there are two changes:
1. ability for client to register to a chat server (it is needed because else the server doesn't know the clients)
2. ability and requirement for the client to fetch data instead of the server sending them data immediately when new data is available