### PR TITLE
DroneAPI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ name = "wgl_repo_2024"
 edition = "2021"
 
 [dependencies]
+crossbeam-channel = "0.5.13"

--- a/examples/drone_usage_example.rs
+++ b/examples/drone_usage_example.rs
@@ -6,7 +6,14 @@ use crossbeam_channel::{select, Receiver, Sender};
 use std::any::Any;
 use std::collections::HashMap;
 
-fn main() {}
+fn main() {
+    //Create some drone
+    // let drone = Drone::new(...);
+
+    //Then start the drone
+    //(not forced to use '.run()', a loop is enough).
+    // drone.run();
+}
 
 impl DroneImplement for Drone {
     fn new(

--- a/examples/drone_usage_example.rs
+++ b/examples/drone_usage_example.rs
@@ -1,9 +1,9 @@
 //THIS IS JUST AN EXAMPLE OF IMPLEMENTATION
 
 use crate::api::drone::Drone;
+use crate::types::command::Command;
 use crate::types::packet::{Packet, PacketType};
 use crate::types::source_routing_header::NodeId;
-use crate::types::command::Command;
 use crossbeam_channel::{select, Receiver, Sender};
 use std::collections::HashMap;
 use std::thread;
@@ -13,14 +13,14 @@ fn main() {
     // by the initialization controller
     let handler = thread::spawn(move || {
         let id = 0;
-        let drone = Drone::new(id, /*require  other parameter here not given*/);
+        let drone = Drone::new(id /*require  other parameter here not given*/);
 
         drone.run();
     });
 }
 
 // Example of drone implementation
-struct MyDrone{
+struct MyDrone {
     id: NodeId,
     sim_contr_send: Sender<Command>,
     sim_contr_recv: Receiver<Command>,
@@ -52,9 +52,8 @@ impl Drone for MyDrone {
     }
 }
 
-
-impl MyDrone{
-    fn run_internal(&mut self){
+impl MyDrone {
+    fn run_internal(&mut self) {
         loop {
             select! {
                 recv(self.get_packet_receiver()) -> packet_res => {

--- a/examples/drone_usage_example.rs
+++ b/examples/drone_usage_example.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::thread;
 
 fn main() {
-    // something like that will be done
+    // Something like this will be done
     // by the initialization controller
     let handler = thread::spawn(move || {
         let id = 0;

--- a/examples/drone_usage_example.rs
+++ b/examples/drone_usage_example.rs
@@ -1,0 +1,56 @@
+//THIS IS JUST AN EXAMPLE OF IMPLEMENTATION
+
+use crate::api::drone::{Drone, DroneImplement};
+use crate::types::packet::{Packet, PacketType};
+use crossbeam_channel::{select, Receiver, Sender};
+use std::any::Any;
+use std::collections::HashMap;
+
+fn main() {}
+
+impl DroneImplement for Drone {
+    fn new(
+        id: NodeId,
+        scs: Sender<Command>,
+        scr: Receiver<Command>,
+        ps: HashMap<NodeId, Sender<Packet>>,
+        pr: Receiver<Packet>,
+        pdr: f32,
+    ) -> Drone {
+        Drone {
+            drone_id: id,
+            sim_contr_send: scs,
+            sim_contr_recv: scr,
+            packet_send: ps,
+            packet_recv: pr,
+            pdr: (pdr * 100.0) as u8,
+        }
+    }
+}
+
+impl Drone {
+    fn run(&mut self) {
+        loop {
+            select! {
+                recv(self.get_packet_receiver()) -> packet_res => {
+                    if let Ok(packet) = packet_res {
+                    // each match branch may call a function to handle it to make it more readable
+                        match packet.pack_type {
+                            PacketType::Nack(nack) => todo!(),
+                            PacketType::Ack(ack) => todo!(),
+                            PacketType::MsgFragment(fragment) => todo!()
+                        }
+                    }
+                },
+                recv(self.get_sim_controller_receiver()) -> command_res => {
+                    if let Ok(command) = command_res {
+                        //handle the simulation controller's command
+                    }
+                }
+            }
+        }
+    }
+    fn add_channel(&mut self, id: NodeId, sender: Sender<Packet>) {
+        self.packet_send.insert(id, sender);
+    }
+}

--- a/examples/drone_usage_example.rs
+++ b/examples/drone_usage_example.rs
@@ -5,14 +5,17 @@ use crate::types::packet::{Packet, PacketType};
 use crossbeam_channel::{select, Receiver, Sender};
 use std::any::Any;
 use std::collections::HashMap;
+use std::thread;
 
 fn main() {
-    //Create some drone
-    // let drone = Drone::new(...);
+    let handler = thread::spawn(move || {
+        //Create some drone
+        // let drone = Drone::new(...);
 
-    //Then start the drone
-    //(not forced to use '.run()', a loop is enough).
-    // drone.run();
+        //Then start the drone
+        //(not forced to use '.run()', a loop is enough).
+        // drone.run();
+    });
 }
 
 impl DroneImplement for Drone {

--- a/src/api/drone.rs
+++ b/src/api/drone.rs
@@ -1,5 +1,32 @@
+use std::collections::HashMap;
+use crate::types::source_routing_header::NodeId;
+use crossbeam_channel::{Receiver, Sender};
 use crate::types::packet::Packet;
 
-pub trait DroneAble {
-    fn forward_packet(&self, packet: Packet) -> bool;
+//This struct will be used inside the threads created by the initializer.
+pub struct Drone {
+    pub drone_id: NodeId,
+    pub sim_contr_send: Sender<Packet>, //Not packet.
+    pub sim_contr_recv: Receiver<Packet>, //Not packet.
+    pub packet_send: HashMap<NodeId, Sender<Packet>>, //All the sender to other nodes.
+    pub packet_recv: Receiver<Packet>, //This drone receiver, that will be linked to a sender given to every other drone.
+    pub pdr: u8, //Would keep it in % to occupy less space, but could be f32.
 }
+
+impl Drone {
+    pub fn new(id: NodeId, scs: Sender<Packet>, scr: Receiver<Packet>, ps: HashMap<NodeId, Sender<Packet>>, pr: Receiver<Packet>, pdr: f32) -> Drone {
+        Drone {
+            drone_id: id,
+            sim_contr_send: scs,
+            sim_contr_recv: scr,
+            packet_send: ps,
+            packet_recv: pr,
+            pdr: (pdr*100.0) as u8,
+        }
+    }
+}
+
+pub trait DroneImplement {
+    fn run(&mut self) {}
+}
+

--- a/src/api/drone.rs
+++ b/src/api/drone.rs
@@ -1,32 +1,26 @@
-use std::collections::HashMap;
+use crate::types::command::Command;
+use crate::types::packet::Packet;
 use crate::types::source_routing_header::NodeId;
 use crossbeam_channel::{Receiver, Sender};
-use crate::types::packet::Packet;
+use std::collections::HashMap;
 
 //This struct will be used inside the threads created by the initializer.
 pub struct Drone {
     pub drone_id: NodeId,
-    pub sim_contr_send: Sender<Packet>, //Not packet.
-    pub sim_contr_recv: Receiver<Packet>, //Not packet.
+    pub sim_contr_send: Sender<Command>,   //Not packet.
+    pub sim_contr_recv: Receiver<Command>, //Not packet.
     pub packet_send: HashMap<NodeId, Sender<Packet>>, //All the sender to other nodes.
     pub packet_recv: Receiver<Packet>, //This drone receiver, that will be linked to a sender given to every other drone.
-    pub pdr: u8, //Would keep it in % to occupy less space, but could be f32.
-}
-
-impl Drone {
-    pub fn new(id: NodeId, scs: Sender<Packet>, scr: Receiver<Packet>, ps: HashMap<NodeId, Sender<Packet>>, pr: Receiver<Packet>, pdr: f32) -> Drone {
-        Drone {
-            drone_id: id,
-            sim_contr_send: scs,
-            sim_contr_recv: scr,
-            packet_send: ps,
-            packet_recv: pr,
-            pdr: (pdr*100.0) as u8,
-        }
-    }
+    pub pdr: u8,                       //Would keep it in % to occupy less space, but could be f32.
 }
 
 pub trait DroneImplement {
-    fn run(&mut self) {}
+    fn new_drone(
+        id: NodeId,
+        scs: Sender<Command>,
+        scr: Receiver<Command>,
+        ps: HashMap<NodeId, Sender<Packet>>,
+        pr: Receiver<Packet>,
+        pdr: f32,
+    ) -> Drone;
 }
-

--- a/src/api/drone.rs
+++ b/src/api/drone.rs
@@ -1,11 +1,11 @@
 use crate::types::command::Command;
+use crate::types::packet::Packet;
 use crate::types::source_routing_header::NodeId;
 use crossbeam_channel::{Receiver, Sender};
-use crate::types::packet::Packet;
 
 // This is a drone of a group
 // Pass to it only what it need to know
-pub trait Drone{
+pub trait Drone {
     fn new(
         id: NodeId,
         sim_contr_send: Sender<Command>,

--- a/src/api/drone.rs
+++ b/src/api/drone.rs
@@ -13,9 +13,9 @@ pub trait Drone{
         packet_recv: Receiver<Packet>,
         pdr: f32,
     ) -> Self;
+    // The list packet_send would be crated empty inside new.
     // Other nodes are added by sending command
-    // using the simulation control channel to send
-    // Command(AddChannel(...))
+    // using the simulation control channel to send 'Command(AddChannel(...))'.
 
     fn run(&mut self);
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,2 +1,2 @@
-mod drone;
+pub mod drone;
 pub mod simulation_controller;

--- a/src/types/command.rs
+++ b/src/types/command.rs
@@ -1,0 +1,9 @@
+use crate::types::packet::Packet;
+use crate::types::source_routing_header::NodeId;
+use crossbeam_channel::Sender;
+
+pub enum Command {
+    ADDCHANNEL(NodeId, Sender<Packet>),
+    REMOVECHANNEL(NodeId),
+    CRASH,
+}

--- a/src/types/command.rs
+++ b/src/types/command.rs
@@ -3,7 +3,7 @@ use crate::types::source_routing_header::NodeId;
 use crossbeam_channel::Sender;
 
 pub enum Command {
-    ADDCHANNEL(NodeId, Sender<Packet>),
-    REMOVECHANNEL(NodeId),
-    CRASH,
+    AddChannel(NodeId, Sender<Packet>),
+    RemoveChannel(NodeId),
+    Crash,
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,4 @@
+pub mod command;
 pub mod message;
 pub mod packet;
 pub mod source_routing_header;


### PR DESCRIPTION
New iteration of the drone API, that combines the two proposal shown in the last WG.

The structure proposed aims to be created inside a thread, where it'll contain all the information needed to running the drone.
The list of the channel on which the drone can communicate will be updated a runtime via a command from the channel that will also be assigned to the simulation controller (might also be used during creation by the iniziator, since the senders can be duplicated).

The struct Drone is now strictly API, but we'll still leave the example of implementation availbe, for those who might need it.