### PR TITLE
Adding registration for Client to Chat

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -239,6 +239,7 @@ pub enum MessageContent{
 	ReqMedia(u64),
 
 	ReqClientList,
+	ReqRegistrationToChat,
 	ReqMessageSend { to: NodeId, message: Vec<u8> },
 	// Do we need request of new messages? or directly sent by server?
 
@@ -413,6 +414,7 @@ Notice that these messages are not subject to the rules of fragmentation, in fac
 
 ### Chat Messages
 
+- C -> S : registration_to_chat,
 - C -> S : client_list?
 - S -> C : client_list!(list_of_client_ids)
 - C -> S : message_for?(client_id, message)

--- a/src/types/message.rs
+++ b/src/types/message.rs
@@ -25,6 +25,7 @@ pub enum MessageContent {
     ReqMedia(u64),
 
     ReqClientList,
+    ReqRegistrationToChat,
     ReqMessageSend { to: NodeId, message: Vec<u8> },
 
     // Server -> Client


### PR DESCRIPTION
As it stand now it is assumed that the server know all the client. But that is false, at the start both client and server only know to which drone are connected.

Also in the project-main.pdf (the file that we need to follow and cannot change) it is clearly stated that this is needed: "In order to use a Communication server, a client must register to it."

So, it is required to request for registration by the part of client.