### PR TITLE
PDR

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -60,6 +60,8 @@ A drone is characterized by a parameter that regulates what to do when a packet 
 
 Packet Drop Rate: The drone drops the received packet with probability equal to the Packet Drop Rate.
 
+The PDR can be up to 100%, and the routing algorithm of every group should find a way to eventually work around this.
+
 # Messages and fragments
 
 Recall that there are: Content servers (that is, Text and Media servers) and Communication servers. These servers are used by clients to implement applications.


### PR DESCRIPTION
Seems like a joke, but we actually never found a commond ground on this, so the idea is to vote this via telegram to not lose WGM time.
Not having a cap to the PDR would force every group to find a way to solve it and consequently optimize the network, while with a cap to it one could just assume that the message will eventually pass and don't care about this.
This is my proposal, and I'm sure someone may be against it. If this shouldn't pass, I expect the opposition to propose another solution, otherwise this will remain unspecified and free choice of the groups I guess, but this last solution doesn't sound really smart.