### PR TITLE
Simulation controller's commands

### DIFF
--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -10,5 +10,7 @@ pub enum Command {
     //These are messages sent back to the sim controller.
     //The channel uses the same enum.
     Topology(NodeId, my_pdr: f32, nghb: HashMap<NodeId>),
-    MessageSent(src: NodeId, trg: NodeId, msg: Message)
+    MessageSent(src: NodeId, trg: NodeId, msg: Message),
+    MessageDropped(src: NodeId, my_pdr: f32, trg: NodeID, msg: Message),
+    Error(src: NodeId, trg: NodeId, msg: Message)
 }


### PR DESCRIPTION
Updated the enum 'Command' to contain all the useful commands and messages, based on the ones in the protocol.