### PR TITLE
wg_config now uses NodeId

### DIFF
--- a/crates/wg_config/Cargo.toml
+++ b/crates/wg_config/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.215", features = ["derive"], optional = true }
+wg_network = { path = "../wg_network" }
 
 [features]
 serialize = ["dep:serde"]

--- a/crates/wg_config/src/config.rs
+++ b/crates/wg_config/src/config.rs
@@ -1,26 +1,27 @@
 #[cfg(feature = "serialize")]
 use serde::Deserialize;
+use wg_network::NodeId;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Deserialize))]
 pub struct Drone {
-    pub id: u64,
-    pub connected_drone_ids: Vec<u64>,
-    pub pdr: f64,
+    pub id: NodeId,
+    pub connected_drone_ids: Vec<NodeId>,
+    pub pdr: f32,
 }
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Deserialize))]
 pub struct Client {
-    pub id: u64,
-    pub connected_drone_ids: Vec<u64>,
+    pub id: NodeId,
+    pub connected_drone_ids: Vec<NodeId>,
 }
 
 #[derive(Debug)]
 #[cfg_attr(feature = "serialize", derive(Deserialize))]
 pub struct Server {
-    pub id: u64,
-    pub connected_drone_ids: Vec<u64>,
+    pub id: NodeId,
+    pub connected_drone_ids: Vec<NodeId>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
also pdr was changed to f32 to be consistent with the drone trait implementation