### PR TITLE
New message structure

### DIFF
--- a/crates/wg_packet/src/message.rs
+++ b/crates/wg_packet/src/message.rs
@@ -1,69 +1,127 @@
-use crate::packet::Fragment;
-use wg_network::topology::ServerType;
 use wg_network::{NodeId, SourceRoutingHeader};
 
 #[derive(Debug, Clone)]
-pub struct Message {
-    pub message_data: MessageData,
+pub struct Message<M: MessageContent> {
+    pub message_data: MessageData<M>,
     pub routing_header: SourceRoutingHeader,
 }
 
 // Only part fragmentized
 #[derive(Debug, Clone)]
-pub struct MessageData {
+pub struct MessageData<M: MessageContent> {
     pub source_id: NodeId,
     pub session_id: u64,
-    pub content: MessageContent,
+    pub content: M,
+}
+
+pub trait MessageContent {
+    fn serialize(&self) -> String;
+    fn deserialize(serialized: String) -> Result<Self, String>
+    where
+        Self: Sized;
+}
+
+// ReqServerType,
+#[derive(Debug, Clone)]
+pub enum TextRequest {
+    FileList,
+    File(u64),
+}
+
+impl MessageContent for TextRequest {
+    fn serialize(&self) -> String {
+        match self {
+            TextRequest::FileList => "FileList".to_string(),
+            TextRequest::File(id) => format!("File({})", id),
+        }
+    }
+
+    fn deserialize(serialized: String) -> Result<Self, String> {
+        if serialized == "FileList" {
+            Ok(TextRequest::FileList)
+        } else if let Ok(id) = serialized
+            .trim_start_matches("File(")
+            .trim_end_matches(')')
+            .parse()
+        {
+            Ok(TextRequest::File(id))
+        } else {
+            Err("Failed to deserialize TextRequest".to_string())
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
-pub enum MessageContent {
-    // Client -> Server
-    ReqServerType,
-    ReqFilesList,
-    ReqFile(u64),
-    ReqMedia(u64),
-
-    ReqClientList,
-    ReqRegistrationToChat,
-    ReqMessageSend { to: NodeId, message: Vec<u8> },
-
-    // Server -> Client
-    RespServerType(ServerType),
-    RespFilesList(Vec<u64>),
-    RespFile(Vec<u8>),
-    RespMedia(Vec<u8>),
-    ErrUnsupporedRequestType,
-    ErrRequestedNotFound,
-
-    RespClientList(Vec<NodeId>),
-    RespMessageFrom { from: NodeId, message: Vec<u8> },
-    ErrWrongClientId,
+pub enum MediaRequest {
+    Media(u64),
 }
 
-impl Message {
-    // takes message and returns the data struct serialized in a String
-    // so it goes from the actual data struct to a String
-    #[allow(unused_variables)]
-    pub fn serialize(&self) -> String {
-        unimplemented!()
+impl MessageContent for MediaRequest {
+    fn serialize(&self) -> String {
+        todo!()
     }
-
-    // takes the content String and makes an instance of Message from it
-    #[allow(unused_variables)]
-    pub fn deserialize(serialized: String) -> Message {
-        unimplemented!()
+    fn deserialize(_: String) -> Result<Self, String> {
+        todo!()
     }
+}
 
-    // takes the String and splits it into Fragments
-    #[allow(unused_variables)]
-    pub fn disassembly(serialized: String) -> Vec<Fragment> {
-        unimplemented!()
+#[derive(Debug, Clone)]
+pub enum ChatRequest {
+    ClientList,
+    Register(NodeId),
+    SendMessage { to: NodeId, message: String },
+}
+
+impl MessageContent for ChatRequest {
+    fn serialize(&self) -> String {
+        todo!()
     }
+    fn deserialize(_: String) -> Result<Self, String> {
+        todo!()
+    }
+}
 
-    // takes a bunch of Fragments and composes them in a serialized string.
-    #[allow(unused_variables)]
-    pub fn assembly(fragments: Vec<Fragment>) -> String {
-        unimplemented!()
+#[derive(Debug, Clone)]
+pub enum FileResponse {
+    FileList(Vec<u64>),
+    File(String),
+    NotFound,
+}
+
+impl MessageContent for FileResponse {
+    fn serialize(&self) -> String {
+        todo!()
+    }
+    fn deserialize(_: String) -> Result<Self, String> {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum MediaResponse {
+    Media(Vec<u8>), // should we use some other type?
+}
+
+impl MessageContent for MediaResponse {
+    fn serialize(&self) -> String {
+        todo!()
+    }
+    fn deserialize(_: String) -> Result<Self, String> {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ChatResponse {
+    RespClientList(Vec<NodeId>),
+    RespMessageFrom { from: NodeId, message: Vec<u8> },
+}
+
+impl MessageContent for ChatResponse {
+    fn serialize(&self) -> String {
+        todo!()
+    }
+    fn deserialize(_: String) -> Result<Self, String> {
+        todo!()
     }
 }


### PR DESCRIPTION
# New Message Structure
## `MessageContent` trait
As you can see, I created a trait `MessageContent`. This makes it so that you can treat different kinds of messages in different ways, so that for example `ChatServer` only need to know how to process `ChatRequest`s in order to create `ChatResponse`s.
## Example
Why should we accept this pull request?
Would you prefer something like
```rust
impl ChatServer {
    fn handle_request(&self, request: ChatRequest) {
        // simply handle chat-server requests
        unimplemented!()
    }

    fn send_response(&self, response: ChatResponse) {
        // simply handle chat-server responses
        unimplemented!()
    }
}
```
or something like
```rust
impl ChatServer {
    fn handle_request(&self, message_content: MessageContentSuperMegaEnumOrSmth) {
        match message_content {
            RqstChatClientList => unimplemented!(),
            RqstChatClientRegistration(id) => unimplemented!(),
            RqstTextFileList => panic!("WTF?"),
            RspnMedia(vec) => panic!("Why am I getting this?"),
            RqstToDoABackflip(wtf) => panic!("I don't know how to do a backflip 😭"),
            RspnWHAAAAAT => im_lost!("panic"),
        }
    }

    fn send_response(&self, message_content: MessageContentSuperMegaEnumOrSmth) {
        // same as above
        // don't make me find other stupid stuff...
        unimplemented!()
    }
}
```
(The first one, you would prefer the first one)
## Message check
f course somewhere the check that the request/response is of the right type should be somewhere, but where? Simple! The `MessageContent::deserialize` function should return a `Err(String)` (could be other type of errors).
## Server types
I have just a new issue with this system (otherwise basically perfect 🗿), how do we know what kind of client/server is a specific client/server? That's actually something to think about, either we include it in the flood or we create a request for every request/response type, such as `ChatRequest::IsChatServer` with `ChatResponse::IsChatServer(bool)`.
## Trait implications
Another thing to discuss is that, since this is a new trait, it makes it possible that every group just implements its own set of request/response.
## Work In Progress
This is just a draft, if this PR gets accepted, I will work on it more!