### PR TITLE
Update min number drones for client

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -41,7 +41,7 @@ connected_drone_ids = ["connected_id1", "..."] # max 2 entries
 ```
 - note that `connected_drone_ids` cannot contain `client_id` nor repetitions
 - note that a client cannot connect to other clients or servers
-- note that a client can be connected to at most two drones
+- note that a client can be connected to at least one and at most two drones
 
 ### Servers
 Any number of servers, each formatted as:


### PR DESCRIPTION
As suggested, this small change was moved to a separate pr.
The protocol doesn't explicitly specify the min number of drones the client should be connected to, so I'm suggesting to set it to 1 and call it a day.