### PR TITLE
removed time::Instant

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -194,9 +194,8 @@ pub struct MessageData {
 If a drone receives a Message and can forward it to the next hop, it also sends an Ack to the client.
 
 ```rust
-pub struct Ack{
+pub struct Ack {
 	fragment_index: u64,
-	time_received: std::time::Instant
 }
 ```
 
@@ -212,7 +211,6 @@ This message cannot be dropped by drones due to Packet Drop Rate.
 ```rust
 pub struct Nack {
 	fragment_index: u64,
-	time_of_fail: std::time::Instant,
 	nack_type: NackType
 }
 

--- a/crates/wg_packet/src/packet.rs
+++ b/crates/wg_packet/src/packet.rs
@@ -21,7 +21,6 @@ pub enum PacketType {
 #[derive(Debug, Clone)]
 pub struct Nack {
     pub fragment_index: u64,
-    pub time_of_fail: std::time::Instant,
     pub nack_type: NackType,
 }
 
@@ -35,7 +34,6 @@ pub enum NackType {
 #[derive(Debug, Clone)]
 pub struct Ack {
     pub fragment_index: u64,
-    pub time_received: std::time::Instant,
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Remove time::Instant
Remove time::Instant from Ack and Nack. Why are they even there, they are not realistic in a real world scenario and they are not tipical values that you can send through a network. Plus they do not serve any use, change my mind.