### PR TITLE
Drone ids

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -25,11 +25,11 @@ Any number of drones, each formatted as:
 ```TOML
 [[drone]]
 id = "drone_id"
-connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
+connected_node_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
 pdr = "pdr"
 ```
 - note that the `pdr` is defined between 0 and 1 (0.05 = 5%).
-- note that `connected_drone_ids` cannot contain `drone_id` nor repetitions
+- note that `connected_node_ids` cannot contain `drone_id` nor repetitions
 
 ### Clients
 Any number of clients, each formatted as:

--- a/crates/wg_config/src/config.rs
+++ b/crates/wg_config/src/config.rs
@@ -6,7 +6,7 @@ use wg_network::NodeId;
 #[cfg_attr(feature = "serialize", derive(Deserialize))]
 pub struct Drone {
     pub id: NodeId,
-    pub connected_drone_ids: Vec<NodeId>,
+    pub connected_node_ids: Vec<NodeId>,
     pub pdr: f32,
 }
 

--- a/examples/config/input.toml
+++ b/examples/config/input.toml
@@ -1,16 +1,16 @@
 [[drone]]
 id = 1
-connected_drone_ids = [2, 3]
+connected_node_ids = [2, 3]
 pdr = 0.05
 
 [[drone]]
 id = 2
-connected_drone_ids = [1,3,4]
+connected_node_ids = [1, 3, 4]
 pdr = 0.03
 
 [[drone]]
 id = 3
-connected_drone_ids = [2,1,4]
+connected_node_ids = [2, 1, 4]
 pdr = 0.14
 
 [[client]]
@@ -23,4 +23,4 @@ connected_drone_ids = [1]
 
 [[server]]
 id = 6
-connected_drone_ids = [2,3]
+connected_drone_ids = [2, 3]

--- a/examples/config/parser.rs
+++ b/examples/config/parser.rs
@@ -9,7 +9,7 @@ use std::fs;
 use wg_2024::config::Config;
 
 fn main() {
-    let config_data = fs::read_to_string("input.toml").expect("Unable to read config file");
+    let config_data = fs::read_to_string("examples/config/input.toml").expect("Unable to read config file");
     // having our structs implement the Deserialize trait allows us to use the toml::from_str function to deserialize the config file into each of them
     let config: Config = toml::from_str(&config_data).expect("Unable to parse TOML");
     println!("{:#?}", config);

--- a/examples/config/parser.rs
+++ b/examples/config/parser.rs
@@ -9,7 +9,8 @@ use std::fs;
 use wg_2024::config::Config;
 
 fn main() {
-    let config_data = fs::read_to_string("examples/config/input.toml").expect("Unable to read config file");
+    let config_data =
+        fs::read_to_string("examples/config/input.toml").expect("Unable to read config file");
     // having our structs implement the Deserialize trait allows us to use the toml::from_str function to deserialize the config file into each of them
     let config: Config = toml::from_str(&config_data).expect("Unable to parse TOML");
     println!("{:#?}", config);


### PR DESCRIPTION
## Config
Ambiguous name connected_drone_ids in wg_2024::config::Drone but a drone can be connected to clients and server.
I renamed connected_drone_ids to connected_node_ids

Also if you did
```bash
cargo run --example parser --features="serialize"
```

before it would panic cause the path of config.toml was wrong. Got fixed