### PR TITLE
Simulation Controller commands specification

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -317,7 +317,7 @@ pub enum Command {
     Crash,
     ChangePdr(f32),
     SentPacket(Packet),
-    DroppedPacket(Packet, f32),
+    DroppedPacket(Packet),
 }
 ```
 
@@ -342,7 +342,7 @@ In addition to the commands above, the **SC** and the **drones** can **exclusive
   - `ChangePdr(f32)` this command tells a drone to change its Packet Drop Rate to the new value provided.
 
 - **Drone -> SC**
-  - `DroppedPacket(Packet, f32)`: the drone sends this command every time it drops a packet. The `f32` value is the *Packet Drop Rate* of the drone at the time the packet was dropped. 
+  - `DroppedPacket(Packet)`: the drone sends this command every time it drops a packet.
 
 # **Client-Server Protocol: High-level Messages**
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -327,22 +327,22 @@ Below are documented the commands that can be exchanged between the **SC and any
 
 - **SC -> Node (any)**
 
-  - `Crash`: This commands makes a node crash. Upon receiving this command, the node’s thread should return as soon as possible. The last thing the node should do is to confirm that it is terminating by sending a Crash command to the SC. 
   - `AddChannel(NodeId, Sender<Packet>)`: This command tells a node to add a new **edge** to the node with id `NodeId` and to use the provided `Sender<Packet>` channel to communicate with it. Since we are assuming bidirectional communication, this command must be used **two times** (i.e. to add the edge from `A` to `B`, we must add the `Sender from A to B` and the `Sender from B to A`).
   - `RemoveChannel(NodeId)`: This command tells a node to remove the edge to the node with id `NodeId`. Since we are assuming bidirectional communication, this command must be used **two times** (i.e. to remove the edge from `A` to `B`, we must remove the `Sender from A to B` and the `Sender from B to A`).
 
 - **Node (any) -> SC**
 
-  - `Crash`: used by a node to confirm that it is terminating.
   - `SentPacket(Packet)`: a node sends this command every time it sends a packet to another node (drone, client or server). In this way, the SC can keep track of the network activity.
 
 In addition to the commands above, the **SC** and the **drones** can **exclusively exchange** the following commands:
 
 - **SC -> Drone**
   - `ChangePdr(f32)` this command tells a drone to change its Packet Drop Rate to the new value provided.
+  - `Crash`: This commands makes a node crash. Upon receiving this command, the node’s thread should return as soon as possible. The last thing the node should do is to confirm that it is terminating by sending a Crash command to the SC. 
 
 - **Drone -> SC**
   - `DroppedPacket(Packet)`: the drone sends this command every time it drops a packet.
+  - `Crash`: used by a node to confirm that it is terminating.
 
 # **Client-Server Protocol: High-level Messages**
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -316,8 +316,8 @@ pub enum Command {
     RemoveChannel(NodeId),
     Crash,
     ChangePdr(f32),
-    SentMessage(Packet),
-    DroppedMessage(Packet)
+    SentPacket(Packet),
+    DroppedPacket(Packet, f32),
 }
 ```
 
@@ -334,7 +334,7 @@ Below are documented the commands that can be exchanged between the **SC and any
 - **Node (any) -> SC**
 
   - `Crash`: used by a node to confirm that it is terminating.
-  - `SentMessage(Packet)`: a node sends this command every time it sends a message to another node (drone, client or server). In this way, the SC can keep track of the network activity.
+  - `SentPacket(Packet)`: a node sends this command every time it sends a packet to another node (drone, client or server). In this way, the SC can keep track of the network activity.
 
 In addition to the commands above, the **SC** and the **drones** can **exclusively exchange** the following commands:
 
@@ -342,7 +342,7 @@ In addition to the commands above, the **SC** and the **drones** can **exclusive
   - `ChangePdr(f32)` this command tells a drone to change its Packet Drop Rate to the new value provided.
 
 - **Drone -> SC**
-  - `DroppedMessage(Packet)`: the drone sends this command every time it drops a message. 
+  - `DroppedPacket(Packet, f32)`: the drone sends this command every time it drops a packet. The `f32` value is the *Packet Drop Rate* of the drone at the time the packet was dropped. 
 
 # **Client-Server Protocol: High-level Messages**
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -308,7 +308,7 @@ TODO
 # Simulation Controller
 
 Like nodes, the **Simulation Controller** (SC) runs on a thread. It must retain a means of communication with all nodes of the network, even when drones go down. 
-The Simulation controller can send different commands to the nodes (drones, clients and servers) through a reserved channel. The **command** list of available commands is as follows:
+The Simulation controller can send and receive different commands to/from the nodes (drones, clients and servers) through reserved channels. The list of available **commands** is as follows:
 
 ```rust
 pub enum Command {
@@ -323,11 +323,11 @@ pub enum Command {
 
 ### Simulation commands
 
-Below are documented the commands that can be exchanged between the SC and any type of node (drone, client, server):
+Below are documented the commands that can be exchanged between the **SC and any type of node** (drone, client, server):
 
 - **SC -> Node (any)**
 
-  - `Crash`: This commands makes a node crash. Upon receiving this command, the node’s thread should return as soon as possible. The last thing the node should do is to confirm that it is terminating by sending a Crash command to the SC. (Possible idea, other proposal are accepted). 
+  - `Crash`: This commands makes a node crash. Upon receiving this command, the node’s thread should return as soon as possible. The last thing the node should do is to confirm that it is terminating by sending a Crash command to the SC. 
   - `AddChannel(NodeId, Sender<Packet>)`: This command tells a node to add a new **edge** to the node with id `NodeId` and to use the provided `Sender<Packet>` channel to communicate with it. Since we are assuming bidirectional communication, this command must be used **two times** (i.e. to add the edge from `A` to `B`, we must add the `Sender from A to B` and the `Sender from B to A`).
   - `RemoveChannel(NodeId)`: This command tells a node to remove the edge to the node with id `NodeId`. Since we are assuming bidirectional communication, this command must be used **two times** (i.e. to remove the edge from `A` to `B`, we must remove the `Sender from A to B` and the `Sender from B to A`).
 
@@ -336,7 +336,7 @@ Below are documented the commands that can be exchanged between the SC and any t
   - `Crash`: used by a node to confirm that it is terminating.
   - `SentMessage(Packet)`: a node sends this command every time it sends a message to another node (drone, client or server). In this way, the SC can keep track of the network activity.
 
-Additionally, to the commands above, the SC and the drones can **exclusively exchange** the following commands:
+In addition to the commands above, the **SC** and the **drones** can **exclusively exchange** the following commands:
 
 - **SC -> Drone**
   - `ChangePdr(f32)` this command tells a drone to change its Packet Drop Rate to the new value provided.

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -7,4 +7,7 @@ pub enum Command {
     AddChannel(NodeId, Sender<Packet>),
     RemoveChannel(NodeId),
     Crash,
+    ChangePdr(f32),
+    SentMessage(Packet),
+    DroppedMessage(Packet)
 }

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -9,5 +9,5 @@ pub enum Command {
     Crash,
     ChangePdr(f32),
     SentMessage(Packet),
-    DroppedMessage(Packet)
+    DroppedMessage(Packet),
 }

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -8,6 +8,6 @@ pub enum Command {
     RemoveChannel(NodeId),
     Crash,
     ChangePdr(f32),
-    SentMessage(Packet),
-    DroppedMessage(Packet),
+    SentPacket(Packet),
+    DroppedPacket(Packet, f32),
 }

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -9,5 +9,5 @@ pub enum Command {
     Crash,
     ChangePdr(f32),
     SentPacket(Packet),
-    DroppedPacket(Packet, f32),
+    DroppedPacket(Packet),
 }


### PR DESCRIPTION
The purpose of this PR is to define the commands that can be exchanged between the nodes (clients, servers and drones) and the Simulation Controller. 

The commands that I identified are the following: 
```rust
pub enum Command {
    AddChannel(NodeId, Sender<Packet>),
    RemoveChannel(NodeId),
    Crash,
    ChangePdr(f32),
    SentMessage(Packet),
    DroppedMessage(Packet)
}
```

You can check the command explanation directly from the PR, thus I won't put it here. My idea is to keep only one `Command` enum to avoid the definition of multiple channels. 

In the specification I clearly stated in which direction each message can be sent, therefore if the WG prefers to split the Commands it would be a small job.

**P.S.**: for the `Crash` command I wrote the following: `This command makes a node crash. Upon receiving this command, the node’s thread should return as soon as possible. The last thing the node should do is to confirm that it is terminating by sending a Crash command to the SC. ` The last part is just an idea of how we could get the confirmation that the node is terminating instead of periodically checking from the SC that the node crashed. I'm open to other ideas.