### PR TITLE
Remove DroneOptions

### DIFF
--- a/crates/wg_drone/src/drone.rs
+++ b/crates/wg_drone/src/drone.rs
@@ -1,18 +1,8 @@
 use crossbeam_channel::{Receiver, Sender};
+use std::collections::HashMap;
 use wg_controller::Command;
 use wg_network::NodeId;
 use wg_packet::Packet;
-use std::collections::HashMap;
-
-#[derive(Debug, Clone)]
-pub struct DroneOptions {
-    pub id: NodeId,
-    pub sim_contr_send: Sender<Command>,
-    pub sim_contr_recv: Receiver<Command>,
-    pub packet_send: HashMap<NodeId, Sender<Packet>>,
-    pub packet_recv: Receiver<Packet>,
-    pub pdr: f32,
-}
 
 /// This is the drone interface.
 /// Each drone's group must implement it
@@ -20,7 +10,14 @@ pub trait Drone {
     /// The list packet_send would be crated empty inside new.
     /// Other nodes are added by sending command
     /// using the simulation control channel to send 'Command(AddChannel(...))'.
-    fn new(options: DroneOptions) -> Self;
+    fn new(
+        id: NodeId,
+        sim_contr_send: Sender<Command>,
+        sim_contr_recv: Receiver<Command>,
+        packet_send: HashMap<NodeId, Sender<Packet>>,
+        packet_recv: Receiver<Packet>,
+        pdr: f32,
+    ) -> Self;
 
     fn run(&mut self);
 }

--- a/crates/wg_drone/src/drone.rs
+++ b/crates/wg_drone/src/drone.rs
@@ -2,12 +2,14 @@ use crossbeam_channel::{Receiver, Sender};
 use wg_controller::Command;
 use wg_network::NodeId;
 use wg_packet::Packet;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct DroneOptions {
     pub id: NodeId,
     pub sim_contr_send: Sender<Command>,
     pub sim_contr_recv: Receiver<Command>,
+    pub packet_send: HashMap<NodeId, Sender<Packet>>,
     pub packet_recv: Receiver<Packet>,
     pub pdr: f32,
 }

--- a/examples/drone/drone_usage.rs
+++ b/examples/drone/drone_usage.rs
@@ -75,10 +75,12 @@ fn main() {
         let id = 1;
         let (sim_contr_send, sim_contr_recv) = crossbeam_channel::unbounded();
         let (_packet_send, packet_recv) = crossbeam_channel::unbounded();
+        let packet_send = HashMap::new();
         let mut drone = MyDrone::new(DroneOptions {
             id,
             sim_contr_recv,
             sim_contr_send,
+            packet_send,
             packet_recv,
             pdr: 0.1,
         });

--- a/examples/drone/drone_usage.rs
+++ b/examples/drone/drone_usage.rs
@@ -7,7 +7,6 @@ use wg_2024::controller::Command;
 use wg_2024::drone::Drone;
 use wg_2024::network::NodeId;
 use wg_2024::packet::{Packet, PacketType};
-use wg_internal::drone::DroneOptions;
 
 /// Example of drone implementation
 struct MyDrone {
@@ -15,19 +14,26 @@ struct MyDrone {
     sim_contr_send: Sender<Command>,
     sim_contr_recv: Receiver<Command>,
     packet_recv: Receiver<Packet>,
-    pdr: u8,
+    pdr: f32,
     packet_send: HashMap<NodeId, Sender<Packet>>,
 }
 
 impl Drone for MyDrone {
-    fn new(options: DroneOptions) -> Self {
+    fn new(
+        id: NodeId,
+        sim_contr_send: Sender<Command>,
+        sim_contr_recv: Receiver<Command>,
+        packet_send: HashMap<NodeId, Sender<Packet>>,
+        packet_recv: Receiver<Packet>,
+        pdr: f32,
+    ) -> Self {
         Self {
-            id: options.id,
-            sim_contr_send: options.sim_contr_send,
-            sim_contr_recv: options.sim_contr_recv,
-            packet_recv: options.packet_recv,
-            pdr: (options.pdr * 100.0) as u8,
-            packet_send: HashMap::new(),
+            id,
+            sim_contr_send,
+            sim_contr_recv,
+            packet_send,
+            packet_recv,
+            pdr,
         }
     }
 
@@ -76,14 +82,14 @@ fn main() {
         let (sim_contr_send, sim_contr_recv) = crossbeam_channel::unbounded();
         let (_packet_send, packet_recv) = crossbeam_channel::unbounded();
         let packet_send = HashMap::new();
-        let mut drone = MyDrone::new(DroneOptions {
+        let mut drone = MyDrone::new(
             id,
-            sim_contr_recv,
             sim_contr_send,
+            sim_contr_recv,
             packet_send,
             packet_recv,
-            pdr: 0.1,
-        });
+            0.1,
+        );
 
         drone.run();
     });


### PR DESCRIPTION
This small pull request includes the removal of the `DroneOptions` struct  and updates to the example usage to reflect these changes. In my opinion it does not make sense to have an extra useless wrapper (as you can see in the changed example).