### PR TITLE
Drone Crash Behavior

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -74,7 +74,7 @@ A drone is characterized by a parameter called PDR(Packet Drop Rate), This param
 A drone can receive a `DroneCommand::Crash` message (shown in the [Simulation Controller section](https://github.com/WGL-2024/WGL_repo_2024/blob/main/AP-protocol.md#simulation-controller) and defined in `wg_2024::controller::DroneCommand`).
 
 ### Expected behavior
-From the moment the drone receives the message it must not send any other messages and its thread should return as soon as possible
+From the moment the drone receives the `DroneCommand::Crash` it must not send any other `Packet` nor `Message` and its thread should return as soon as possible
 
 > Note that this means that the drone crashing can lead to potentially any type of Packet being dropped, which is an option that must be considered by the Client/Server routing protocol
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -74,7 +74,9 @@ A drone is characterized by a parameter called PDR(Packet Drop Rate), This param
 A drone can receive a `DroneCommand::Crash` message (shown in the [Simulation Controller section](https://github.com/WGL-2024/WGL_repo_2024/blob/main/AP-protocol.md#simulation-controller) and defined in `wg_2024::controller::DroneCommand`).
 
 ### Expected behavior
-The drone's thread should return as soon as possible.
+From the moment the drone receives the message it must not send any other messages and its thread should return as soon as possible
+
+> Note that this means that the drone crashing can lead to potentially any type of Packet being dropped, which is an option that must be considered by the Client/Server routing protocol
 
 ## Interacting with crashed drone
 Drones need to handle the possibility of being requested to send a `Packet` to a crashed drone
@@ -82,7 +84,7 @@ Drones need to handle the possibility of being requested to send a `Packet` to a
 ### Expected behavior
 Drones that get forwarded a `Packet` which has a crashed drone as the next hop should behave as if the crashed drone was not in their neighbors (return new Nack of `NackType::ErrorInRouting(<crashed_drone_id>)`)
 
-Drones are expected to remove from their `packet_send` Vector the `Sender` for the crashed drone as soon as possible
+Drones are expected to drop the `Sender<Message>` for the crashed drone as soon as possible
 
 > Note that this means that the Client/Server routing protocols will need to handle the unexpected `ErrorInRouting` Nacks
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -61,14 +61,30 @@ connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
 
 ### Additional requirements
 - note that the **Network Initialization File** should never contain two **nodes** with the same `id` value
+# Drone Behavior
+## Packet Drop Rate
 
-# Drone parameters: Packet Drop Rate
+A drone is characterized by a parameter called PDR(Packet Drop Rate), This parameter is provided in the Network Initialization File.
 
-A drone is characterized by a parameter that regulates what to do when a packet is received, that thus influences the simulation. This parameter is provided in the Network Initialization File.
+### Expected behavior
+ The drone drops the received packet with probability equal to the Packet Drop Rate.
 
-Packet Drop Rate: The drone drops the received packet with probability equal to the Packet Drop Rate.
+> Note that The PDR can be up to 100%, and the routing algorithm of every group should find a way to eventually work around this.
+## Crashing
+A drone can receive a `DroneCommand::Crash` message (shown in the [Simulation Controller section](https://github.com/WGL-2024/WGL_repo_2024/blob/main/AP-protocol.md#simulation-controller) and defined in `wg_2024::controller::DroneCommand`).
 
-The PDR can be up to 100%, and the routing algorithm of every group should find a way to eventually work around this.
+### Expected behavior
+The drone's thread should return as soon as possible.
+
+## Interacting with crashed drone
+Drones need to handle the possibility of being requested to send a `Packet` to a crashed drone
+
+### Expected behavior
+Drones that get forwarded a `Packet` which has a crashed drone as the next hop should behave as if the crashed drone was not in their neighbors (return new Nack of `NackType::ErrorInRouting(<crashed_drone_id>)`)
+
+Drones are expected to remove from their `packet_send` Vector the `Sender` for the crashed drone as soon as possible
+
+> Note that this means that the Client/Server routing protocols will need to handle the unexpected `ErrorInRouting` Nacks
 
 # Messages and fragments
 


### PR DESCRIPTION
# Recap
- Drones that get a `DroneCommand::Crash` have to return without sending any other message or packet
- Drones that are asked to forward a Packet to a crashed drone should detect that the drone has crashed and return an `ErrorInRouting` Nack

# Why should we use this approach
I believe that this approach is more realistic and inline with the idea of having a simulation where things can go wrong and you need to be able to handle this kind of errors

This approach does not make the Drone implementation more complex (instead I believe it is easier than other solutions that were discussed in regards to the drone)

Instead, the Client and Server routing protocol needs to handle the potential loss of packets that were inside the `Receiver` of the crashed drones, for example by implementing a timeout logic

# But what does the project main say
In this section it seems to suggest that the drone crash failure could be notified to client and server:

> In real world, clients
and servers use timeouts to infer that a packet has been dropped or that a drone
has crashed. In this project, for simplification, these failures are notified to clients
and servers as specific messages that cannot be dropped by drones.

But also in the line directly below it says that we should handle the event of an **ack** getting lost:

> That is, the protocols and the code should answer these questions: What happens
if a packet gets lost? What happens if the acknowledgement of a certain packet
gets lost?

which is in contrast with what we kept in the faulty protocol(the first version said that only messages could be dropped)

I think that this PR is still aligned with the ideas above, making drones able to drop just Messages, but still having the possibility of other types of messages being lost, by way of the drone crash

# What other options do we have?
## Option 1
In order:
1. simulation controller send a command to all of the neighbors of the node `needs_to_crash`, telling them to remove their sender to `needs_to_crash`
2. simulation controller in some way confirms that all those nodes have stopped forwarding Packets to `needs_to_crash`
3. simulation controller sends crash command to `needs_to_crash` 
4. `needs_to_crash` sends all of the Packets remaining in its Receiver
5. `needs_to_crash` exits
## Option 2
In order:
1. simulation controller sends crash command to `needs_to_crash`
2. `needs_to_crash` sends a custom Message to all of its neighbors telling them that it's going to crash
3. neighbors might need to send some kind of ack to be sure none of them send packets in the next steps
4. `needs_to_crash` sends all Packets in its receiver
6. `needs_to_crash` exits

# Voting
To make things quicker we can give these options for the vote:
- Yes to the PR
- No, I prefer option 1, please implement it
- No, I prefer option 2, please implement it
- No, I don't like any of the proposal and I want to keep the protocol as it is

If someone has a counter proposal please comment or make a PR so that it can be added to the voting 
