### PR TITLE
Specify drone implementation

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -18,10 +18,16 @@ The **Network Initializer**:
 2. checks that the initialization file adheres to the formatting and restrictions defined in the section below
 3. checks that the initialization file represents a bidirectional graph
 4. according to the network topology, defined in the initialization file, performs the following actions(in no particular order):
-   - spawns the node threads
-   - spawns the simulation controller thread
+   - initializes the drones, distributing the implementations bought from the other groups(`impl`) as evenly as possible, having at most a difference of 1 between the group with the most drones running and the one with the least:
+		- for 10 drones and 10 `impl`, 1 distinct `impl` for each drone
+		- for 15 drones and 10 `impl`, each `impl` should be used at least once
+		- for 5 drones and 10 `impl`, only some of the `impl` will be used
+		- for 10 drones and 1 `impl`, all drones will have that `impl` 
    - sets up the Rust channels for communicating between nodes that are connected in the topology
    - sets up the Rust channels for communication between nodes and the simulation controller
+   - spawns the node threads
+   - spawns the simulation controller thread
+
 
 ## Network Initialization File
 The **Network Initialization File** is in the `.toml` format, and structured as explained below:
@@ -61,6 +67,7 @@ connected_drone_ids = ["connected_id1", "connected_id2", "connected_id3", "..."]
 
 ### Additional requirements
 - note that the **Network Initialization File** should never contain two **nodes** with the same `id` value
+- Note that the **Network Initialization File** does not define if a drone should use a particular implementation, every group is expected to import the drones they bought at the fair in the Network Initializer, and distribute them as explained in the previous section 
 
 # Drone parameters: Packet Drop Rate
 


### PR DESCRIPTION
Issue mentioned in #49, I propose a way to initialize the drones without cluttering the initialization file, in my opinion we have no need to specify that a single drone needs to have a particular group implementation. The important bit is that we want the implementations to be equally spread.

There is still the possibility (up to the group's network initializer) of debugging a single drone by filling the network with just their drone. 

It also considers the possibility of not having a 10-drone network, to be able to try all kinds of networks.

If you disagree, and you think we should be able to define in the initialization file the implementation for each drone, please comment or make a PR with a counter proposal so that we can vote on it