### PR TITLE
Nack errors

### DIFF
--- a/crates/wg_packet/src/packet.rs
+++ b/crates/wg_packet/src/packet.rs
@@ -19,16 +19,10 @@ pub enum PacketType {
 }
 
 #[derive(Debug, Clone)]
-pub struct Nack {
-    pub fragment_index: u64,
-    pub nack_type: NackType,
-}
-
-#[derive(Debug, Clone)]
-pub enum NackType {
+pub enum Nack {
     ErrorInRouting(NodeId), // contains id of not neighbor
     DestinationIsDrone,
-    Dropped,
+    Dropped(u64), // fragment id of dropped fragment
     UnexpectedRecipient(NodeId),
 }
 


### PR DESCRIPTION
This pull request includes changes to the `PacketType` enum in the `crates/wg_packet/src/packet.rs` file. The most important changes involve refactoring the `Nack` structure and its associated `NackType` enum to simplify the codebase.

Refactoring changes:

* [`crates/wg_packet/src/packet.rs`](diffhunk://#diff-afac9b4d5950e1e88c70424af11d4d2b4639afb2250336d64e0325d30757839aL22-R25): Removed the `Nack` struct and merged its fields into the `Nack` enum, which now includes the `Dropped` variant with a `u64` parameter to store the fragment id of the dropped fragment.

This is important because `Nack`s aren't generated exclusively by fragments, so they shouldn't include `fragment_id`. Now the `Dropped` variant contains the u64 index of the fragment that was dropped.