### PR TITLE
Add NodeId to Nack::Dropped

### DIFF
--- a/crates/wg_packet/src/packet.rs
+++ b/crates/wg_packet/src/packet.rs
@@ -22,7 +22,7 @@ pub enum PacketType {
 pub enum Nack {
     ErrorInRouting(NodeId), // contains id of not neighbor
     DestinationIsDrone,
-    Dropped(u64), // fragment id of dropped fragment
+    Dropped(NodeId, u64), // (NodeId of the drone which dropped the packet, fragment id of dropped fragment)
     UnexpectedRecipient(NodeId),
 }
 


### PR DESCRIPTION
This PR adds the NodeId of the drone which dropped the packet to the enum Nack::Dropped. This allows clients and servers to choose packet routes in the network according to the amount of packets dropped by each drone.