### PR TITLE
Why remove fragment_index from Nack?

### DIFF
--- a/crates/wg_packet/src/packet.rs
+++ b/crates/wg_packet/src/packet.rs
@@ -19,10 +19,16 @@ pub enum PacketType {
 }
 
 #[derive(Debug, Clone)]
-pub enum Nack {
+pub struct Nack {
+    pub fragment_index: u64,
+    pub nack_type: NackType,
+}
+
+#[derive(Debug, Clone)]
+pub enum NackType {
     ErrorInRouting(NodeId), // contains id of not neighbor
     DestinationIsDrone,
-    Dropped(u64), // fragment id of dropped fragment
+    Dropped,
     UnexpectedRecipient(NodeId),
 }
 


### PR DESCRIPTION
I did not understand why PR #90 was approved and merged. In my opinion it breaks the protocol and it is necessary to go back to the previous version. 

The first thing I would like to clarify is that in my opinion Nacks can only be created for `MsgFragments`: all other messages cannot be dropped or suffer errors. 

Also, each time a Nack is created, it results in the loss of a `MsgFragment`, so it is necessary to have the ability to report to the host the `fragment_index` to be retransmitted.