### PR TITLE
Management of messages inside the channels at crash

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -437,7 +437,6 @@ The Simulation controller can send and receive different commands to/from the no
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
-    GetNghb(),
     CloseChannel(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -466,8 +466,6 @@ The crash command is then sent. Upon receiving this command, the drone’s threa
 - Ack, Nack and FloodResponse should still be forwarded to the next hop.
 - Other types of packets will send an 'ErrorInRouting' Nack back, since the drone has crashed.
 
-`GetNghb()`: This command gives a vector of the neighbours of the chosen drone back to the Simulation Controller.
-
 `CloseChannel(nghb_id)`: This command close the channel with a neighbour drone.
 
 `AddSender(dst_id, crossbeam::Sender)`: This command adds `dst_id` to the drone neighbors, with `dst_id` crossbeam::Sender.

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -448,7 +448,6 @@ pub enum DroneCommand {
 pub enum NodeEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
-    NghbNodes(Vec<NodeId>),
 }
 ```
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -460,8 +460,9 @@ The Simulation Controller can execute the following tasks:
 The Simulation Controller can send the following commands to drones:
 
 `Crash`: This command makes a drone crash.
-The Simulation Controller first asks the drone that should crash for the Id's of its neighbours. It then sends a 'CloseChannel' command to them, stopping the messages incoming to the drone that needs to be crushed.
-The crash command is then sent. Upon receiving this command, the drone’s thread should process all messages in its channel and then return as soon as possible.
+The Simulation Controller, while sending this command to the drone, will send also a 'RemoveSender' command to its neighbours, so that the crushing drone will be able to process the remaining messages without any other incoming.
+At the same time the Crash command will be sent to the drone, which will put it in 'Crashing behavior'. In this state the drone will process the remaining messages as follows, then when all the sender to it's channel will be removed, and the channel will be emptied, trying to listen to it will give back an error, which will mean that the drone can finally crash.
+While in this state, the drone will process the remaining messages as follows:
 - FloodRequest can be lost during the process.
 - Ack, Nack and FloodResponse should still be forwarded to the next hop.
 - Other types of packets will send an 'ErrorInRouting' Nack back, since the drone has crashed.

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -480,8 +480,6 @@ The Simulation Controller can receive the following events from nodes:
 
 `PacketDropped(packet)`: This event indicates that node has dropped a packet. All the informations about the `src_id`, `dst_id` and `path` are stored in the packet routing header.
 
-`NghbNodes(Vec<NodeId>)`: This event contains all the neighbours of the drone.
-
 ## Note on commands and events
 
 Due to the importance of these messages, drones MUST prioritize handling commands from the simulation controller over messages and fragments.

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -459,7 +459,7 @@ The Simulation Controller can execute the following tasks:
 The Simulation Controller can send the following commands to drones:
 
 `Crash`: This command makes a drone crash.
-The Simulation Controller first asks the drone that should crahs for the Id's of its neighbours. It then sends a 'CloseChannel' command to them, stopping the messages incoming to the drone that needs to be crushed.
+The Simulation Controller first asks the drone that should crash for the Id's of its neighbours. It then sends a 'CloseChannel' command to them, stopping the messages incoming to the drone that needs to be crushed.
 The crash command is then sent. Upon receiving this command, the drone’s thread should process all messages in its channel and then return as soon as possible.
 - FloodRequest can be lost during the process.
 - Ack, Nack and FloodResponse should still be forwarded to the next hop.

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -467,7 +467,7 @@ The crash command is then sent. Upon receiving this command, the drone’s threa
 
 `GetNghb()`: This command gives a vector of the neighbours of the chosen drone back to the Simulation Controller.
 
-`CloseChannel(nghb_id)`: This command close the channel with a neighbout drone.
+`CloseChannel(nghb_id)`: This command close the channel with a neighbour drone.
 
 `AddSender(dst_id, crossbeam::Sender)`: This command adds `dst_id` to the drone neighbors, with `dst_id` crossbeam::Sender.
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -458,7 +458,16 @@ The Simulation Controller can execute the following tasks:
 
 The Simulation Controller can send the following commands to drones:
 
-`Crash`: This command makes a drone crash. Upon receiving this command, the drone’s thread should return as soon as possible.
+`Crash`: This command makes a drone crash.
+The Simulation Controller first asks the drone that should crahs for the Id's of its neighbours. It then sends a 'CloseChannel' command to them, stopping the messages incoming to the drone that needs to be crushed.
+The crash command is then sent. Upon receiving this command, the drone’s thread should process all messages in its channel and then return as soon as possible.
+- FloodRequest can be lost during the process.
+- Ack, Nack and FloodResponse should still be forwarded to the next hop.
+- Other types of packets will send an 'ErrorInRouting' Nack back, since the drone has crashed.
+
+`GetNghb()`: This command gives a vector of the neighbours of the chosen drone back to the Simulation Controller.
+
+`CloseChannel(nghb_id)`: This command close the channel with a neighbout drone.
 
 `AddSender(dst_id, crossbeam::Sender)`: This command adds `dst_id` to the drone neighbors, with `dst_id` crossbeam::Sender.
 
@@ -471,6 +480,8 @@ The Simulation Controller can receive the following events from nodes:
 `PacketSent(packet)`: This event indicates that node has sent a packet. All the informations about the `src_id`, `dst_id` and `path` are stored in the packet routing header.
 
 `PacketDropped(packet)`: This event indicates that node has dropped a packet. All the informations about the `src_id`, `dst_id` and `path` are stored in the packet routing header.
+
+`NghbNodes(Vec<NodeId>)`: This event contains all the neighbours of the drone.
 
 ## Note on commands and events
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -437,6 +437,8 @@ The Simulation controller can send and receive different commands to/from the no
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
+    GetNghb(),
+    CloseChannel(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),
     Crash,
@@ -447,6 +449,7 @@ pub enum DroneCommand {
 pub enum NodeEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
+    NghbNodes(Vec<NodeId>),
 }
 ```
 

--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -437,7 +437,7 @@ The Simulation controller can send and receive different commands to/from the no
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
-    CloseChannel(NodeId),
+    RemoveSender(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),
     Crash,
@@ -466,7 +466,7 @@ The crash command is then sent. Upon receiving this command, the drone’s threa
 - Ack, Nack and FloodResponse should still be forwarded to the next hop.
 - Other types of packets will send an 'ErrorInRouting' Nack back, since the drone has crashed.
 
-`CloseChannel(nghb_id)`: This command close the channel with a neighbour drone.
+`RemoveSender(nghb_id)`: This command close the channel with a neighbour drone.
 
 `AddSender(dst_id, crossbeam::Sender)`: This command adds `dst_id` to the drone neighbors, with `dst_id` crossbeam::Sender.
 

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -5,6 +5,8 @@ use wg_packet::Packet;
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
+    GetNghb(),
+    CloseChannel(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),
     Crash,
@@ -15,4 +17,5 @@ pub enum DroneCommand {
 pub enum NodeEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
+    NghbNodes(Vec<NodeId>),
 }

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -16,5 +16,4 @@ pub enum DroneCommand {
 pub enum NodeEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
-    NghbNodes(Vec<NodeId>),
 }

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -5,7 +5,7 @@ use wg_packet::Packet;
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
-    CloseChannel(NodeId),
+    RemoveSender(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),
     Crash,

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -5,7 +5,6 @@ use wg_packet::Packet;
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
-    GetNghb(),
     CloseChannel(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),


### PR DESCRIPTION
Since our implementation of the network doesn't use timers, but we instead use Acks and Nacks, in the case a drone would crash we would still need a way to manage eventual incoming packets to it.

With this method we would stop every other message to arrive to the drone, and then process everything left before crashing as soon as possible.

Also quickly specified how the crashing drone would treat the different types of packet.