### PR TITLE
Clarification of SC - Nodes commands

### DIFF
--- a/AP-protocol.md
+++ b/AP-protocol.md
@@ -415,9 +415,6 @@ pub enum DroneEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
 }
-
-// For backward compatibility with the previous naming
-type NodeEvent = DroneEvent;
 ```
 
 The Simulation Controller can execute the following tasks:
@@ -428,11 +425,13 @@ The Simulation Controller can execute the following tasks:
 
 The Simulation Controller can send the following commands to drones:
 
-`Crash`: This command makes a drone crash. Upon receiving this command, the drone’s thread should return as soon as possible.
-
-`AddSender(dst_id, crossbeam::Sender)`: This command adds `dst_id` to the drone neighbors, with `dst_id` crossbeam::Sender.
+`AddSender(dst_id, crossbeam::Sender)`: This command adds `dst_id` to the drone neighbors, with `dst_id` crossbeam::
+Sender.
 
 `SetPacketDropRate(pdr)`: This command alters the pdr of a drone.
+
+`Crash`: This command makes a drone crash. Upon receiving this command, the drone’s thread should return as soon as
+possible.
 
 #### Note:
 Commands issued by the Simulation Controller must preserve the initial network requirements:

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -5,6 +5,7 @@ use wg_packet::Packet;
 /// From controller to drone
 #[derive(Debug, Clone)]
 pub enum DroneCommand {
+    RemoveSender(NodeId),
     AddSender(NodeId, Sender<Packet>),
     SetPacketDropRate(f32),
     Crash,
@@ -14,6 +15,9 @@ pub enum DroneCommand {
 impl PartialEq for DroneCommand {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
+            (DroneCommand::RemoveSender(node1), DroneCommand::RemoveSender(node2)) => {
+                node1 == node2
+            }
             (DroneCommand::AddSender(node1, sender1), DroneCommand::AddSender(node2, sender2)) => {
                 node1 == node2 && sender1.same_channel(sender2)
             }
@@ -32,4 +36,5 @@ impl PartialEq for DroneCommand {
 pub enum DroneEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
+    ControllerShortcut(Packet),
 }

--- a/crates/wg_controller/src/command.rs
+++ b/crates/wg_controller/src/command.rs
@@ -29,7 +29,7 @@ impl PartialEq for DroneCommand {
 /// From drone to controller
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "partial_eq", derive(PartialEq))]
-pub enum NodeEvent {
+pub enum DroneEvent {
     PacketSent(Packet),
     PacketDropped(Packet),
 }

--- a/crates/wg_drone/src/drone.rs
+++ b/crates/wg_drone/src/drone.rs
@@ -13,7 +13,7 @@ pub trait Drone {
     /// using the simulation control channel to send 'Command(AddChannel(...))'.
     fn new(
         id: NodeId,
-        controller_send: Sender<NodeEvent>,
+        controller_send: Sender<DroneEvent>,
         controller_recv: Receiver<DroneCommand>,
         packet_recv: Receiver<Packet>,
         packet_send: HashMap<NodeId, Sender<Packet>>,

--- a/crates/wg_drone/src/drone.rs
+++ b/crates/wg_drone/src/drone.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
 use crossbeam_channel::{Receiver, Sender};
-use wg_controller::{DroneCommand, NodeEvent};
+use wg_controller::{DroneCommand, DroneEvent};
 use wg_network::NodeId;
 use wg_packet::Packet;
 
 #[derive(Debug, Clone)]
 pub struct DroneOptions {
     pub id: NodeId,
-    pub controller_send: Sender<NodeEvent>,
+    pub controller_send: Sender<DroneEvent>,
     pub controller_recv: Receiver<DroneCommand>,
     pub packet_recv: Receiver<Packet>,
     pub packet_send: HashMap<NodeId, Sender<Packet>>,

--- a/examples/drone/drone_usage.rs
+++ b/examples/drone/drone_usage.rs
@@ -69,6 +69,7 @@ impl MyDrone {
             DroneCommand::AddSender(_node_id, _sender) => todo!(),
             DroneCommand::SetPacketDropRate(_pdr) => todo!(),
             DroneCommand::Crash => unreachable!(),
+            DroneCommand::RemoveSender(_node_id) => todo!(),
         }
     }
 }

--- a/examples/drone/drone_usage.rs
+++ b/examples/drone/drone_usage.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::{select_biased, unbounded, Receiver, Sender};
 use std::collections::HashMap;
 use std::{fs, thread};
 use wg_2024::config::Config;
-use wg_2024::controller::{DroneCommand, NodeEvent};
+use wg_2024::controller::{DroneCommand, DroneEvent};
 use wg_2024::drone::Drone;
 use wg_2024::network::NodeId;
 use wg_2024::packet::{Packet, PacketType};
@@ -13,7 +13,7 @@ use wg_internal::drone::DroneOptions;
 /// Example of drone implementation
 struct MyDrone {
     id: NodeId,
-    controller_send: Sender<NodeEvent>,
+    controller_send: Sender<DroneEvent>,
     controller_recv: Receiver<DroneCommand>,
     packet_recv: Receiver<Packet>,
     pdr: f32,
@@ -75,7 +75,7 @@ impl MyDrone {
 
 struct SimulationController {
     drones: HashMap<NodeId, Sender<DroneCommand>>,
-    node_event_recv: Receiver<NodeEvent>,
+    node_event_recv: Receiver<DroneEvent>,
 }
 
 impl SimulationController {


### PR DESCRIPTION
This PR updates the documentation to address a potential source of confusion in the Simulation Controller (SC) command protocol. Specifically, the SC commands and events have been restricted to drones, as they were mistakenly described as applicable to all nodes (including clients and servers). The changes reflect the following rationale:

1. **Unnecessary Overhead for Clients and Servers**:
   - Most commands (`PacketDropped`, `Crash`, `SetPacketDropRate`) are only relevant to drones and serve no purpose for clients or servers.
   - This avoids imposing unnecessary constraints or requiring additional attributes for clients and servers to communicate with the SC.

2. **Customizability**:
   - `AddSender(dst_id, crossbeam::Sender)` and `PacketSent(packet)` are the only potentially useful commands for clients and servers. Groups can now define their own commands for hosts (clients/servers) in separate, custom enums tailored to their needs.

>  Note: I also removed an unnecessary and nonsensical section, probably the result of an erroneous copy/paste, as I didn’t want to create two separate PRs for something trivial.