### PR TITLE
Small `FloodResponse` generation fix

### DIFF
--- a/crates/wg_packet/src/flood.rs
+++ b/crates/wg_packet/src/flood.rs
@@ -61,7 +61,7 @@ impl FloodRequest {
                 source_routing.append_hop(self.initiator_id);
             }
             _ => {}
-        }        
+        }
         Packet::new_flood_response(
             source_routing,
             session_id,

--- a/crates/wg_packet/src/flood.rs
+++ b/crates/wg_packet/src/flood.rs
@@ -53,7 +53,7 @@ impl FloodRequest {
                 .rev()
                 .collect(),
         );
-        if source_routing.is_empty() || source_routing.destination() != Some(self.initiator_id) {
+        if source_routing.destination() != Some(self.initiator_id) {
             source_routing.append_hop(self.initiator_id);
         }
         Packet::new_flood_response(

--- a/crates/wg_packet/src/flood.rs
+++ b/crates/wg_packet/src/flood.rs
@@ -48,19 +48,13 @@ impl FloodRequest {
         let mut source_routing = SourceRoutingHeader::initialize(
             self.path_trace
                 .iter()
-                .cloned()
                 .map(|(id, _)| id)
+                .cloned()
                 .rev()
                 .collect(),
         );
-        match source_routing.destination() {
-            Some(destination) if destination != self.initiator_id => {
-                source_routing.append_hop(self.initiator_id);
-            }
-            None => {
-                source_routing.append_hop(self.initiator_id);
-            }
-            _ => {}
+        if source_routing.is_empty() || source_routing.destination() != Some(self.initiator_id) {
+            source_routing.append_hop(self.initiator_id);
         }
         Packet::new_flood_response(
             source_routing,

--- a/crates/wg_packet/src/flood.rs
+++ b/crates/wg_packet/src/flood.rs
@@ -53,11 +53,15 @@ impl FloodRequest {
                 .rev()
                 .collect(),
         );
-        if let Some(destination) = source_routing.destination() {
-            if destination != self.initiator_id {
+        match source_routing.destination() {
+            Some(destination) if destination != self.initiator_id => {
                 source_routing.append_hop(self.initiator_id);
             }
-        }
+            None => {
+                source_routing.append_hop(self.initiator_id);
+            }
+            _ => {}
+        }        
         Packet::new_flood_response(
             source_routing,
             session_id,


### PR DESCRIPTION
There was a little problem in the code that I didn't notice when developing it: if the `FloodRequest` has an empty `path_trace` (i.e. if it is the drone directly attached to the initiator and the initiator didn't add itself in the `path_trace`) the method didn't generate a correct `routing_header` for the `FloodResponse`.
This problem shouldn't occur in a simulation, but just to be precise I think we can include this small change in the code.